### PR TITLE
feat(ignoreFlag): Update filtering ignore flag.

### DIFF
--- a/src/Components/ProductHistory.jsx
+++ b/src/Components/ProductHistory.jsx
@@ -6,41 +6,40 @@ export default class ProductHistory extends Component {
     localStorage.setItem('productHistory', JSON.stringify(tmp));
 
     this.state = {
-      productHistory: JSON.parse(localStorage.getItem('productHistory')) || [],
+      productHistoryOrigin: JSON.parse(localStorage.getItem('productHistory')) || [],
+      productHistoryModified: [],
       brandSelected: [],
       ignoreFlag: false,
     };
   }
 
   shouldComponentUpdate(nextState) {
-    if (this.state.productHistory !== nextState.productHistory) {
+    if (this.state.productHistoryModified !== nextState.productHistoryModified) {
       return true;
     }
   }
 
   onClickIgnoreBox = () => {
-    const { ignoreFlag, productHistory } = this.state;
+    const { ignoreFlag, productHistoryOrigin } = this.state;
     if (!ignoreFlag) {
       this.setState({
-        productHistory: productHistory.filter(product => !product.ignore),
+        productHistoryModified: productHistoryOrigin.filter(product => !product.ignore),
         ignoreFlag: true,
       });
     } else {
       this.setState({
-        productHistory: JSON.parse(localStorage.getItem('productHistory')),
+        productHistoryModified: productHistoryOrigin,
         ignoreFlag: false,
       });
     }
   };
 
   render() {
-    const { productHistory } = this.state;
-
+    const { productHistoryOrigin, productHistoryModified } = this.state;
     return (
       <>
         <h1>사용자 상품 조회 이력</h1>
         <section>
-          {/* 브랜드, 노관심, 최신순, 낮은가격 */}
           <div>
             브랜드
             <label>
@@ -63,20 +62,37 @@ export default class ProductHistory extends Component {
             <option>낮은 가격</option>
           </select>
         </section>
-        {productHistory ? (
+        {productHistoryModified.length ? (
           <div>
-            <h2>여기에 이제 렌더링 할거에요!</h2>
-            {productHistory.map((product, index) => (
+            <h2>상품</h2>
+            {productHistoryModified.map((product, index) => (
               <div key={index} style={{ margin: '1rem 0' }}>
                 <div>상품명: {product.title}</div>
                 <div>브랜드: {product.brand}</div>
                 <div>가격: {product.price}</div>
                 <div>{product.ignore ? `관심없음` : `관심있음`}</div>
+                <hr />
               </div>
             ))}
           </div>
         ) : (
-          <h2>사용자가 아무것도 보질 않았어요!</h2>
+          ``
+        )}
+        {productHistoryOrigin.length && !productHistoryModified.length ? (
+          <div>
+            <h2>상품</h2>
+            {productHistoryOrigin.map((product, index) => (
+              <div key={index} style={{ margin: '1rem 0' }}>
+                <div>상품명: {product.title}</div>
+                <div>브랜드: {product.brand}</div>
+                <div>가격: {product.price}</div>
+                <div>{product.ignore ? `관심없음` : `관심있음`}</div>
+                <hr />
+              </div>
+            ))}
+          </div>
+        ) : (
+          !productHistoryModified.length && <h2>사용자가 아무것도 보질 않았어요!</h2>
         )}
       </>
     );

--- a/src/Components/ProductHistory.jsx
+++ b/src/Components/ProductHistory.jsx
@@ -8,12 +8,30 @@ export default class ProductHistory extends Component {
     this.state = {
       productHistory: JSON.parse(localStorage.getItem('productHistory')) || [],
       brandSelected: [],
+      ignoreFlag: false,
     };
   }
 
-  shouldComponentUpdate() {
-    // 만약 this.state의 brandSelected가 이전과 달랄졌다면, return true
+  shouldComponentUpdate(nextState) {
+    if (this.state.productHistory !== nextState.productHistory) {
+      return true;
+    }
   }
+
+  onClickIgnoreBox = () => {
+    const { ignoreFlag, productHistory } = this.state;
+    if (!ignoreFlag) {
+      this.setState({
+        productHistory: productHistory.filter(product => !product.ignore),
+        ignoreFlag: true,
+      });
+    } else {
+      this.setState({
+        productHistory: JSON.parse(localStorage.getItem('productHistory')),
+        ignoreFlag: false,
+      });
+    }
+  };
 
   render() {
     const { productHistory } = this.state;
@@ -36,7 +54,7 @@ export default class ProductHistory extends Component {
           </div>
           <div>
             <label>
-              <input type="checkbox" name="ignore" value="ignore" />
+              <input onClick={this.onClickIgnoreBox} type="checkbox" name="ignore" value="ignore" />
               관심없는 제품 제외하기
             </label>
           </div>
@@ -48,11 +66,12 @@ export default class ProductHistory extends Component {
         {productHistory ? (
           <div>
             <h2>여기에 이제 렌더링 할거에요!</h2>
-            {productHistory.map(product => (
-              <div style={{ margin: '1rem 0' }}>
+            {productHistory.map((product, index) => (
+              <div key={index} style={{ margin: '1rem 0' }}>
                 <div>상품명: {product.title}</div>
                 <div>브랜드: {product.brand}</div>
                 <div>가격: {product.price}</div>
+                <div>{product.ignore ? `관심없음` : `관심있음`}</div>
               </div>
             ))}
           </div>


### PR DESCRIPTION
### Details

- User clicks ignore checkbox, data below renders differently.

### 구현내용

![mr camel01](https://user-images.githubusercontent.com/52649378/127635700-5fb2186e-7910-4b83-870b-4e2b5462b6c4.gif)

사용자가 박스를 클릭함에 따라 하단 데이터가 조정됩니다.

---

`ProductHistory` 컴포넌트에는 아래와 같은 변수들이 `state` 로 지정되어 있으며,

![image](https://user-images.githubusercontent.com/52649378/127651795-ee7caae3-a6c3-499c-b250-18e5805bd3b4.png)

- `productHistoryOrigin` : 원본데이터
- `productHistoryModified` : 사용자가 필터링 아무거나 건 순간, 편집된 데이터 배열을 가지는 변수

위 짤에 보이는 체크박스에는 아래 이벤트함수가 바인딩됩니다.

![image](https://user-images.githubusercontent.com/52649378/127651926-380a48fb-e198-4f3c-a24d-510d45578742.png)

- `state` 의 `ignoreFlag` 의 상태에 따라 분기문으로 처리하였습니다. 

![image](https://user-images.githubusercontent.com/52649378/127651976-1cf3b4d6-01db-4675-b085-c094255f1764.png)

- 맨 처음에는 81번째줄이 수행됩니다. 
- 하지만 사용자가 조작을 함에따라, 68번째 줄만 수행됩니다. -> 그때는 `productHistoryModified` 의 길이를 보고 81번째 줄을 막습니다.

closes #8 