### PR TITLE
feat(option): Update option sort feature.

### DIFF
--- a/src/Components/ProductHistory.jsx
+++ b/src/Components/ProductHistory.jsx
@@ -10,6 +10,7 @@ export default class ProductHistory extends Component {
       productHistoryModified: [],
       brandSelected: [],
       ignoreFlag: false,
+      sortValue: 'recent,',
     };
   }
 
@@ -34,8 +35,42 @@ export default class ProductHistory extends Component {
     }
   };
 
+  onChangeSort = e => {
+    const sortTargetValue = e.target.value;
+    const { productHistoryOrigin } = this.state;
+    this.setState({
+      sortValue: sortTargetValue,
+    });
+
+    switch (sortTargetValue) {
+      case 'dateRecent':
+        this.setState({
+          productHistoryModified: productHistoryOrigin.sort(
+            (item1, item2) => item1.date - item2.date,
+          ),
+        });
+        break;
+      case 'priceAscend':
+        this.setState({
+          productHistoryModified: productHistoryOrigin.sort(
+            (item1, item2) => item1.price - item2.price,
+          ),
+        });
+        break;
+      case 'priceDescend':
+        this.setState({
+          productHistoryModified: productHistoryOrigin.sort(
+            (item1, item2) => item2.price - item1.price,
+          ),
+        });
+        break;
+      default:
+        console.log('no default');
+    }
+  };
+
   render() {
-    const { productHistoryOrigin, productHistoryModified } = this.state;
+    const { productHistoryOrigin, productHistoryModified, sortValue } = this.state;
     return (
       <>
         <h1>사용자 상품 조회 이력</h1>
@@ -57,9 +92,10 @@ export default class ProductHistory extends Component {
               관심없는 제품 제외하기
             </label>
           </div>
-          <select>
-            <option>최신순</option>
-            <option>낮은 가격</option>
+          <select value={sortValue} onChange={this.onChangeSort}>
+            <option value="dateRecent">최신순</option>
+            <option value="priceAscend">낮은 가격 순서</option>
+            <option value="priceDescend">높은 가격 순서</option>
           </select>
         </section>
         {productHistoryModified.length ? (


### PR DESCRIPTION
### Details

- Can sort by date, price ascending, descending order.

### 구현내용

![mr camel02](https://user-images.githubusercontent.com/52649378/127728052-3cdb0aec-ce53-4c0f-a9b0-c61dd1cc2c3f.gif)

![image](https://user-images.githubusercontent.com/52649378/127727989-72efdae7-941e-44bf-9ffb-f1fe75c80a32.png)

위와 같이 `sortValue` 라는 상태값으로 현재 정렬 상태를 기억합니다.

![image](https://user-images.githubusercontent.com/52649378/127727979-87ed1337-3623-484e-bafd-e58dbaafadeb.png)

그 변수는 위와 같이 `select`, `option` 태그에 사용되며, 

![image](https://user-images.githubusercontent.com/52649378/127728002-bfc02b5e-88d4-41df-a4d9-4f47e8c01a6d.png)

3가지 조건으로 소팅을 진행합니다.

**데이터가 100개뿐이라 일반적인 방법을 사용했습니다.**

closes #10 